### PR TITLE
Add microdata markup

### DIFF
--- a/src/Creitive/Breadcrumbs/Breadcrumbs.php
+++ b/src/Creitive/Breadcrumbs/Breadcrumbs.php
@@ -396,9 +396,10 @@ class Breadcrumbs {
 	 * @param  string  $name
 	 * @param  string  $href
 	 * @param  boolean $isLast
+	 * @param  number  $position
 	 * @return string
 	 */
-	protected function renderCrumb($name, $href, $isLast = false)
+	protected function renderCrumb($name, $href, $isLast = false, $position = null)
 	{
 		if ($this->divider)
 		{
@@ -409,13 +410,26 @@ class Breadcrumbs {
 			$divider = '';
 		}
 
-		if (!$isLast)
+		if ($position != null)
 		{
-			return "<li><a href=\"{$href}\">{$name}</a>{$divider}</li>";
+			$positionMeta = "<meta itemprop=\"position\" content=\"{$position}\" />";
 		}
 		else
 		{
-			return "<li class=\"active\">{$name}</li>";
+			$positionMeta = "";
+		}
+
+		if (!$isLast)
+		{
+			return '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" >'
+				. "<a itemprop=\"item\" href=\"{$href}\"><span itemprop=\"name\">{$name}</span></a>"
+				. "{$positionMeta}{$divider}</li>";
+		}
+		else
+		{
+			return '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" '
+				. "class=\"active\"><span itemprop=\"name\">{$name}</span>"
+				. "{$positionMeta}</li>";
 		}
 	}
 
@@ -432,6 +446,8 @@ class Breadcrumbs {
 		$output = '';
 
 		$hrefSegments = array();
+
+		$position = 1;
 
 		foreach ($this->breadcrumbs as $key => $crumb)
 		{
@@ -453,7 +469,8 @@ class Breadcrumbs {
 				$href = "/{$href}";
 			}
 
-			$output .= $this->renderCrumb($crumb['name'], $href, $isLast);
+			$output .= $this->renderCrumb($crumb['name'], $href, $isLast, $position);
+			$position++;
 		}
 
 		return $output;
@@ -472,8 +489,9 @@ class Breadcrumbs {
 		}
 
 		$cssClasses = implode(' ', $this->breadcrumbsCssClasses);
-		return '<'. $this->listElement .' class="' . $cssClasses .'">' 
-			   . $this->renderCrumbs() 
+		return '<'. $this->listElement . ' itemscope itemtype="http://schema.org/BreadcrumbList"'
+		     .' class="' . $cssClasses .'">'
+			   . $this->renderCrumbs()
 			   . '</'. $this->listElement .'>';
 	}
 


### PR DESCRIPTION
Microdata markup for breadcrumbs allow search engines to locate a page within the website, just like humans do. There are other ways to do it but I believe it is best if this is handled at the core of the breadcrumbs plugin to avoid code duplication. This way all users get proper SEO out of the box :+1: 

This patch adds extra <span /> which may break too strict CSS rules so it might require at least a "minor" package version bump.

More information on breadcrumbs and structured data: https://developers.google.com/structured-data/breadcrumbs