### PR TITLE
Remove metacontent href for last item without href

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -503,7 +503,6 @@ class Breadcrumbs
             } else {
                 return '<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" '
                     . "class=\"{$this->listItemCssClass} active\"><span itemprop=\"name\">{$name}</span>"
-                    . "<meta itemprop=\"item\" content=\"{$href}\" />"
                     . "{$positionMeta}</li>";
             }
         }


### PR DESCRIPTION
https://search.google.com/structured-data/testing-tool/ rules has changed.
If you set a href meta without link, you have an error 	